### PR TITLE
Fewer failing tasks

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4"
+__version__ = "0.5"
 
 import os
 import sys

--- a/__init__.py
+++ b/__init__.py
@@ -75,6 +75,8 @@ def import_sensor_data(zinfo_spcids: List[str], dryrun: bool = False):
         response = res.json()
         values = response.get("waarden", [])
         current_app.logger.info(f"Got {len(values)} values...")
+        if len(values) == 0:
+            return
 
         # Parse response
         df = pd.DataFrame(values)


### PR DESCRIPTION
Arguably, we'd still want to catch situations where an external API endpoint fails to provide data, but I believe the import task itself should not fail by default. In the Z-info case, for example, the external API endpoint has been set up to backfill missing data for up to a day, and we don't mind if there are some gaps, as long as they end up being filled later during the day.